### PR TITLE
Improve directive params for owl carousel

### DIFF
--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -1,41 +1,129 @@
+(function () {
+	'use strict';
+	angular
+		.module('angular-owl-carousel', [])
+		.directive('owlCarousel', [
+			'$parse',
+			owlCarouselDirective
+		]);
 
-(function() {
+	function owlCarouselDirective($parse) {
 
-    angular
-        .module('angular-owl-carousel', [])
-        .directive('owlCarousel', owlCarouselDirective);
+		var owlOptions = [
+			'items',
+			'margin',
+			'loop',
+			'center',
+			'mouseDrag',
+			'touchDrag',
+			'pullDrag',
+			'freeDrag',
+			'merge',
+			'mergeFit',
+			'autoWidth',
+			'startPosition',
+			'URLhashListener',
+			'nav',
+			'navRewind',
+			'navText',
+			'slideBy',
+			'dots',
+			'dotsEach',
+			'dotData',
+			'lazyLoad',
+			'lazyContent',
+			'autoplay',
+			'autoplayTimeout',
+			'autoplayHoverPause',
+			'smartSpeed',
+			'fluidSpeed',
+			'autoplaySpeed',
+			'dotsSpeed',
+			'dragEndSpeed',
+			'callbacks',
+			'responsive',
+			'responsiveRefreshRate',
+			'responsiveBaseElement',
+			'responsiveClass',
+			'video',
+			'videoHeight',
+			'videoWidth',
+			'animateOut',
+			'animateIn',
+			'fallbackEasing',
+			'info',
+			'nestedItemSelector',
+			'itemElement',
+			'stageElement',
+			'navContainer',
+			'dotsContainer',
+			// Classes
+			'themeClass',
+			'baseClass',
+			'itemClass',
+			'centerClass',
+			'activeClass',
+			'navContainerClass',
+			'navClass',
+			'controlsClass',
+			'dotClass',
+			'dotsClass',
+			'autoHeightClass',
+			// Callbacks
+			'onInitialize',
+			'onInitialized',
+			'onResize',
+			'onResized',
+			'onRefresh',
+			'onRefreshed',
+			'onDrag',
+			'onDragged',
+			'onTranslate',
+			'onTranslated',
+			'onChange',
+			'onChanged',
+			'onStopVideo',
+			'onPlayVideo',
+			'onLoadLazy',
+			'onLoadedLazy'
+		];
 
-    function owlCarouselDirective() {
+		return {
+			restrict: 'A',
+			transclude: true,
+			link: function (scope, element, attributes, controller, $transclude) {
 
-        return {
-            restrict: 'A',
-            transclude: true,
-            link: function(scope, element, attributes, controller, $transclude) {
+				var options = {},
+					$element = $(element),
+					owlCarousel = null,
+					propertyName = attributes.owlCarousel;
 
-                var $element = $(element);
-                var owlCarousel = null;
-                var propertyName = attributes.owlCarousel;
-                var options = JSON.parse(attributes.owlOptions);
+				for (var i = 0; i < owlOptions.length; i++) {
+					var opt = owlOptions[i];
+					if (attributes[opt] !== undefined) {
+						options[opt] = $parse(attributes[opt])();
+					}
+				}
 
-                scope.$watchCollection(propertyName, function(newItems, oldItems) {
+				scope.$watchCollection(propertyName, function (newItems, oldItems) {
 
-                    if (owlCarousel) {
-                        owlCarousel.destroy();
-                    }
-                    $element.empty();
+					if (owlCarousel) {
+						owlCarousel.destroy();
+					}
+					$element.empty();
 
-                    for (var i in newItems) {
-                        $transclude(function(clone, scope) {
-                            scope.item = newItems[i];
-                            $element.append(clone[1]);
-                        });
-                    }
+					for (var i in newItems) {
+						$transclude(function (clone, scope) {
+							scope.item = newItems[i];
+							$element.append(clone[1]);
+						});
+					}
 
-                    $element.owlCarousel(options);
-                    owlCarousel = $element.data('owlCarousel');
-                });
-            }
-        };
-    }
+					$element.owlCarousel(options);
+					owlCarousel = $element.data('owlCarousel');
+				});
+			}
+		};
+	}
 
 })();


### PR DESCRIPTION
Hi.
I added all params for owl-carousel2 according to its api docs.
So now we can add params just like that:

```
<div owl-carousel="items" nav="true" items="1">
  <div class="item">{{tem}}</div>
</div>
```

And absence of params won't crash code anymore)
