### PR TITLE
remove data attribute for owl reload 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "angular-owl-carousel",
+  "version": "0.1.0",
+  "description": "Populate Owl Carousel with data from an Angular controller",
+  "main": "src/angular-owl-carousel.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonahbron/angular-owl-carousel.git"
+  },
+  "keywords": [
+    "owl",
+    "carousel",
+    "angular",
+    "directive"
+  ],
+  "author": "Jonah Dahlquist <jonah@nucleussystems.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jonahbron/angular-owl-carousel/issues"
+  },
+  "homepage": "https://github.com/jonahbron/angular-owl-carousel#readme"
+}

--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -7,6 +7,16 @@
 			owlCarouselDirective
 		]);
 
+	if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
+		// Export the *name* of this Angular module
+		// Sample usage:
+		//
+		//   import angularOwlCarousel from './angular-owl-carousel';
+		//   angular.module('app', [angularOwlCarousel]);
+		//
+		module.exports = "angular-owl-carousel";
+	}
+
 	function owlCarouselDirective($parse) {
 
 		var owlOptions = [

--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -11,6 +11,12 @@
 
 		var owlOptions = [
 			'items',
+			'itemsDesktop',
+			'itemsDesktopSmall',
+			'itemsTabletSmall',
+			'itemsTablet',
+			'itemsMobile',
+			'itemsCustom',
 			'margin',
 			'loop',
 			'center',

--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -11,12 +11,6 @@
 
 		var owlOptions = [
 			'items',
-			'itemsDesktop',
-			'itemsDesktopSmall',
-			'itemsTabletSmall',
-			'itemsTablet',
-			'itemsMobile',
-			'itemsCustom',
 			'margin',
 			'loop',
 			'center',

--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -119,6 +119,7 @@
 						});
 					}
 
+					$element.data('owl.carousel', null);
 					$element.owlCarousel(options);
 					owlCarousel = $element.data('owlCarousel');
 				});


### PR DESCRIPTION
In Owl v2+, it doesn't reinitialise the owl list if the data attribute already exists. This means that if the angular item list gets updated, the owl carousel doesn't get updated properly.

This fix allows dynamic update of the angular list.
