### PR TITLE
Add check for owlCarousel  destroy

### DIFF
--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -100,7 +100,7 @@
                             options[currentOptionValue] = scope.owlOptions[currentOptionValue];
                         }
                     }
-                    
+
                     element.addClass('owl-carousel');
 
                     scope.$watchCollection(propertyName, function (newItems) {
@@ -127,7 +127,9 @@
                     });
 
                     scope.$on("$destroy", function () {
-                        owlCarousel.destroy();
+                        if (owlCarousel) {
+                            owlCarousel.destroy();
+                        }
                     });
                 }
             };


### PR DESCRIPTION
I have an error when use ngDialog and angular-owl-carousel on closing ngDialog. I added extra checking owlCarousel exists