### PR TITLE
Fix the error: $injector:strictdi

### DIFF
--- a/src/angular-owl-carousel.js
+++ b/src/angular-owl-carousel.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
     angular.module('angular-owl-carousel', [])
-        .directive('owlCarousel', function ($timeout) {
+        .directive('owlCarousel', ['$timeout',function ($timeout) {
             var owlOptions = [
                 'items',
                 'margin',
@@ -133,5 +133,5 @@
                     });
                 }
             };
-        });
+        }]);
 })();


### PR DESCRIPTION
Explicit annotation required.

AngularJS now requires this and I think it is a good idea to update:
https://docs.angularjs.org/error/$injector/strictdi?p0=function($timeout